### PR TITLE
Adjust card border-radius and shadow

### DIFF
--- a/library/card/scss/_mixins.scss
+++ b/library/card/scss/_mixins.scss
@@ -35,7 +35,7 @@
 
 @mixin amb-create-card-modifiers() {
   &--elevated {
-    @include amb-create-elevation($level: 3, $opacity: 0.1);
+    box-shadow: $amb-card-elevation;
   }
 
   &--borderless {

--- a/library/card/scss/_variables.scss
+++ b/library/card/scss/_variables.scss
@@ -9,4 +9,5 @@ $amb-card-fg-color: amb-color-contrast($amb-card-bg-color);
 $amb-card-border-style: solid;
 $amb-card-border-width: 1px;
 $amb-card-border-color: amb-color-theme('neutral', 30);
-$amb-card-border-radius: amb-border-radius('xlarge');
+$amb-card-border-radius: 12px;
+$amb-card-elevation: 0 3px 12px 0 rgba(0, 0, 0 , 0.15);


### PR DESCRIPTION
### **Description**
Adjust the border-radius value to 12px for .Card class.
Create a new variable for 15 of Alpha shadow (there is currently no detail about the exact value of 15 in CSS, need to ask UI/UX team first). (untuk sekarang kita treat value 15 ini sebagai opacity 0.15)

### **Changes**
add new variable $amb-card-border-radius and set value to 12px
add new variable $amb-card-elevation and set value to 0 3px 12px 0 rgba(0, 0, 0 , 0.15)
change value border-radius in mixins card
change value box-shadow with temporary value because the fix value is not declared from UI/UX

### **User Interface**
In Amar UI
![168262058-9af4254e-6497-4908-89aa-3a9e9912cd8a](https://user-images.githubusercontent.com/22863200/170218521-b70782d9-c582-4420-8ceb-4aa97120d35c.png)

In Msite
![168262144-89c002ef-6aeb-4af0-9380-0fc1b12fbf65](https://user-images.githubusercontent.com/22863200/170218635-a4ec9329-b28c-4998-acd0-8d4049c50504.png)

